### PR TITLE
chore: Add Dockerfile and docker-compose.yml for building and running dyndns service

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM ubuntu:22.04 AS base
+
+RUN apt-get update && apt-get install -y \
+    curl \
+    git \
+    build-essential \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
+ENV PATH="/root/.cargo/bin:${PATH}"
+ADD . dyndns
+WORKDIR /dyndns
+RUN cargo build --release
+RUN mv target/release /app
+WORKDIR /app
+EXPOSE 8079/tcp
+ENTRYPOINT [ "./dyndns" ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+services:
+  dyndns:
+    build: .
+    ports:
+      - "8079:8079"
+    volumes:
+      - ./example-config/config.json:/app/config.json
+      - ./example-config/Rocket.toml:/app/Rocket.toml


### PR DESCRIPTION
Add Docker support with containerized deployment

- Add Dockerfile with Rust build environment
- Add docker-compose.yml for easy service deployment
- Configure port 8079 exposure and config volume mounts
- Enable containerized dyndns service deployment